### PR TITLE
Added function to extract `Data` from `SharedSecret` and `SymmetricKey`

### DIFF
--- a/Sources/LibCrypto/Curve25519.swift
+++ b/Sources/LibCrypto/Curve25519.swift
@@ -49,6 +49,6 @@ public class Curve25519 {
 
         let sharedSecret = try ourPrivate.sharedSecretFromKeyAgreement(with: theirPublic)
 
-        return sharedSecret.x963DerivedSymmetricKey(using: SHA256.self, sharedInfo: Data(), outputByteCount: 32)
+        return SymmetricKey(data: Data(sharedSecret: sharedSecret))
     }
 }

--- a/Sources/LibCrypto/Unwrap.swift
+++ b/Sources/LibCrypto/Unwrap.swift
@@ -1,0 +1,33 @@
+//
+//  File.swift
+//  
+//
+//  Created by aeoliux on 17/05/2024.
+//
+
+import Foundation
+import Crypto
+
+extension Data {
+    /// Initializes a new `Data` object with content extracted from SymmetricKey object
+    ///
+    /// - Parameter symmetricKey: `SymmetricKey` object
+    /// - Returns: `Data` object
+    init(symmetricKey: SymmetricKey) {
+        self.init()
+        self = symmetricKey.withUnsafeBytes {
+            return Data(Array($0))
+        }
+    }
+    
+    /// Initializes a new `Data` object with content extracted from SharedSecret object
+    ///
+    /// - Parameter sharedSecret: `SharedSecret` object
+    /// - Returns: `Data` object
+    init(sharedSecret: SharedSecret) {
+        self.init()
+        self = sharedSecret.withUnsafeBytes {
+            return Data(Array($0))
+        }
+    }
+}

--- a/Tests/LibCryptoTests/Unwrap.swift
+++ b/Tests/LibCryptoTests/Unwrap.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  
+//
+//  Created by aeoliux on 17/05/2024.
+//
+
+import XCTest
+@testable import LibCrypto
+@testable import Crypto
+
+final class UnwrapTest: XCTest {
+    func testSymmetricKey() throws {
+        let data = Curve25519.generateKeyPair().privateKey.data(using: .utf8)!
+        let symmetricKey = SymmetricKey(data: data)
+        XCTAssert(Data(symmetricKey: symmetricKey).elementsEqual(data))
+    }
+}


### PR DESCRIPTION
Hi,
I've implemented a functions to extract raw `Data` object from `SharedSecret` and `SymmetricKey`. Also I fixed function which computes shared secret. `x963DerivedSymmetricKey(using: SHA256.self, sharedInfo: Data(), outputByteCount: 32)` can produce invalid shared secrets, which can be unequal to shared secrets produced by other libraries. I didn't make any changes in the usage of existing functions, so it's safe to merge this PR, but I can do some of them to make this code more Swifty if that's needed.